### PR TITLE
update parser scanGroup bug

### DIFF
--- a/src/core/parser.js
+++ b/src/core/parser.js
@@ -668,10 +668,9 @@ class Parser {
     /**
      * Parse a group enclosed in a pair of braces: `{...}`.
      *
-     * Returns either a group MathAtom, null if not a group.
-     * Returns the group contents MathAtom array if the group was just for formatting.
-     * Returns a group MathAtom with an empty body if an empty
-     * group (i.e. `{}`).
+     * Return a group MathAtom, a MathAtom array, or null if not a group.
+     * Returns a MathAtom array if the group was used only for formatting.
+     * Returns a group MathAtom with an empty body if an empty group (i.e. `{}`).
      * @return {MathAtom}
      * @method module:core/parser#Parser#scanGroup
      * @private

--- a/src/core/parser.js
+++ b/src/core/parser.js
@@ -668,9 +668,9 @@ class Parser {
     /**
      * Parse a group enclosed in a pair of braces: `{...}`.
      *
-     * Return either a group MathAtom or null if not a group.
-     *
-     * Return a group MathAtom with an empty body if an empty
+     * Returns either a group MathAtom, null if not a group.
+     * Returns the group contents MathAtom array if the group was just for formatting.
+     * Returns a group MathAtom with an empty body if an empty
      * group (i.e. `{}`).
      * @return {MathAtom}
      * @method module:core/parser#Parser#scanGroup
@@ -678,9 +678,30 @@ class Parser {
      */
     scanGroup() {
         if (!this.parseToken('{')) return null;
-        const result = new MathAtom(this.parseMode, 'group');
-        result.body = this.scanImplicitGroup(token => token.type === '}');
+        const formatCommands = [
+            'fontseries',
+            'upshape',
+            'fontShape',
+            'tiny',
+            'scriptsize',
+            'footnotesize',
+            'small',
+            'normalsize',
+            'large',
+            'Large',
+            'LARGE',
+            'huge',
+            'Huge',
+            'fontfamily'
+        ];
+        const isFormatGroup = formatCommands.some(c => this.hasCommand(c));
+        const body = this.scanImplicitGroup(token => token.type === '}');
         this.parseToken('}');
+        if (isFormatGroup) {
+            return body;
+        }
+        const result = new MathAtom(this.parseMode, 'group');
+        result.body = body;
         result.latexOpen = '{';
         result.latexClose = '}';
         return result;


### PR DESCRIPTION
- do not parse latex group to mathlist group if group is only mean to encapsulate formatting, which will be stored on atom